### PR TITLE
Exception should not be thrown when running in browser with common JS…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraformer-wkt-parser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Well-Known Text parser",
   "main": "terraformer-wkt-parser.js",
   "directories": {

--- a/src/module-source.js
+++ b/src/module-source.js
@@ -3,10 +3,8 @@
   // Node.
   if(typeof module === 'object' && typeof module.exports === 'object') {
     exports = module.exports = factory(require("terraformer"));
-  }
-
-  // Browser Global.
-  if(typeof navigator === "object") {
+  } else if(typeof navigator === "object") {
+    // Browser Global.
     if (!root.Terraformer){
       throw new Error("Terraformer.WKT requires the core Terraformer library. http://github.com/esri/terraformer")
     }


### PR DESCRIPTION
I tried to use this library with an application that uses webpack to run common JS in the browser.  The problem is that the code assumes that the presence of module.exports means that the code is running in Node.  Moving the browser check into an else block fixes the issue.