### PR TITLE
changing the grammar to allow scientific notation numbers

### DIFF
--- a/spec/wktSpec.js
+++ b/spec/wktSpec.js
@@ -408,6 +408,14 @@ describe("WKT Parser", function() {
     expect(output.type).toEqual("Point");
   });
 
+  it("should parse a POINT with scientific notation coordinates", function(){
+    var input = "POINT (30e0 10 2.0E+001 15)";
+    var output = new Terraformer.WKT.parse(input);
+    expect(output.coordinates).toEqual([30,10,20,15]);
+    expect(output).toBeInstanceOfClass(Terraformer.Point);
+    expect(output.type).toEqual("Point");
+  });
+
   it("should parse a LINESTRING", function(){
     var input = "LINESTRING (30 10, 10 30, 40 40)";
     var output = new Terraformer.WKT.parse(input);

--- a/src/wkt.yy
+++ b/src/wkt.yy
@@ -4,23 +4,23 @@
 
 %%
 
-\s+                           // ignore
-"("                           return '('
-")"                           return ')'
-"-"?[0-9]+("."[0-9]+)?        return 'DOUBLE_TOK'
-"POINT"                       return 'POINT'
-"LINESTRING"                  return 'LINESTRING'
-"POLYGON"                     return 'POLYGON'
-"MULTIPOINT"                  return 'MULTIPOINT'
-"MULTILINESTRING"             return 'MULTILINESTRING'
-"MULTIPOLYGON"                return 'MULTIPOLYGON'
-","                           return 'COMMA'
-"EMPTY"                       return 'EMPTY'
-"M"                           return 'M'
-"Z"                           return 'Z'
-"ZM"                          return 'ZM'
-<<EOF>>                       return 'EOF'
-.                             return "INVALID"
+\s+                                          // ignore
+"("                                          return '('
+")"                                          return ')'
+"-"?[0-9]+("."[0-9]+)?([eE][\-\+]?[0-9]+)?   return 'DOUBLE_TOK'
+"POINT"                                      return 'POINT'
+"LINESTRING"                                 return 'LINESTRING'
+"POLYGON"                                    return 'POLYGON'
+"MULTIPOINT"                                 return 'MULTIPOINT'
+"MULTILINESTRING"                            return 'MULTILINESTRING'
+"MULTIPOLYGON"                               return 'MULTIPOLYGON'
+","                                          return 'COMMA'
+"EMPTY"                                      return 'EMPTY'
+"M"                                          return 'M'
+"Z"                                          return 'Z'
+"ZM"                                         return 'ZM'
+<<EOF>>                                      return 'EOF'
+.                                            return "INVALID"
 
 /lex
 


### PR DESCRIPTION
For issue #7 (unable to parse scientific notation)

I can add more tests if needed.  Also, I wasn't sure if I should include the build artifacts (terraformer-wkt-parser.js and terraformer-wkt-parser.min.js).