### PR TITLE
fix: do not throw on MULTIPOLYGON with empty first outer ring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4743,13 +4743,14 @@
       }
     },
     "vows": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
-      "integrity": "sha1-3QBl8RC6DAptY+hEhRwyCBdtWGc=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.8.2.tgz",
+      "integrity": "sha1-aR95qybM3oC6cm3en+yOc9a88us=",
       "dev": true,
       "requires": {
-        "diff": "~1.0.3",
-        "eyes": ">=0.1.6"
+        "diff": "~1.0.8",
+        "eyes": "~0.1.6",
+        "glob": "^7.1.2"
       },
       "dependencies": {
         "diff": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^0.5.1",
     "tslint": "^4.5.1",
     "typescript": "^2.2.1",
-    "vows": "~0.7.0"
+    "vows": "^0.8.2"
   },
   "directories": {
     "test": "test"

--- a/src/module-source.js
+++ b/src/module-source.js
@@ -255,7 +255,7 @@
   function multiPolygonToWKTMultiPolygon (primitive) {
     var ret = 'MULTIPOLYGON ';
 
-    if (primitive.coordinates === undefined || primitive.coordinates.length === 0 || primitive.coordinates[0].length === 0) {
+    if (primitive.coordinates === undefined || primitive.coordinates.length === 0 || primitive.coordinates[0].length === 0 || primitive.coordinates[0][0].length === 0) {
       ret += 'EMPTY';
 
       return ret;


### PR DESCRIPTION
This is consistent with the handling of empty POLYGONs by the parser.  Bug was found through fuzzing of a dependent package.

( Licensed under : https://github.com/Esri/terraformer-wkt-parser/blob/d885fa81b021c7cd8ad984262720fee3baeb0de5/LICENSE )